### PR TITLE
added tour list pdf with an overview for all day tours for each tour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ my_settings_local.py
 .DS_Store
 myenv.txt
 *.db
+/.env
+/*.code-workspace
+/media

--- a/ortoloco/settings.py
+++ b/ortoloco/settings.py
@@ -372,7 +372,15 @@ ORTOLOCO_TOURS = [
 
 # # test version
 # ORTOLOCO_TOURS = [
-#     {"name": "Fondli", "depot_ids": [1, 11], "local": True},
-#     {"name": "kleines Auto (Renault)", "depot_ids": [2, 3, 4, 5, 12, 13, 14], "local": False},
-#     {"name": "grosses Auto (Opel)", "depot_ids": [6, 7, 8, 9, 10, 15, 16, 17], "local": False}
+#     {"name": "Fondli", "depot_ids": [1, 12], "local": True},
+#     {
+#         "name": "kleines Auto (Renault)",
+#         "depot_ids": [2, 3, 4, 5, 11, 13, 14],
+#         "local": False,
+#     },
+#     {
+#         "name": "grosses Auto (Opel)",
+#         "depot_ids": [6, 7, 8, 9, 10, 15, 16, 17],
+#         "local": False,
+#     },
 # ]

--- a/ortoloco/settings.py
+++ b/ortoloco/settings.py
@@ -8,6 +8,9 @@ DEBUG = os.environ.get("JUNTAGRICO_DEBUG", "True") == "True"
 
 ALLOWED_HOSTS = ['my.ortoloco.ch']
 
+# test version
+# ALLOWED_HOSTS = ['localhost']
+
 DATA_UPLOAD_MAX_NUMBER_FIELDS = None
 
 FILE_UPLOAD_PERMISSIONS = 0o444
@@ -354,7 +357,7 @@ ORTOLOCO_TYPE_SUBSCRIPTIONS = {
     "eier": [23]
 }
 
-# #test version
+# test version
 # ORTOLOCO_TYPE_SUBSCRIPTIONS = {
 #     "gmues": [1],
 #     "obst": [2],
@@ -370,7 +373,7 @@ ORTOLOCO_TOURS = [
     {"name": "grosses Auto (Opel)", "depot_ids": [8, 12, 11, 2, 16, 5, 18, 19], "local": False}
 ]
 
-# # test version
+# test version
 # ORTOLOCO_TOURS = [
 #     {"name": "Fondli", "depot_ids": [1, 12], "local": True},
 #     {
@@ -384,3 +387,11 @@ ORTOLOCO_TOURS = [
 #         "local": False,
 #     },
 # ]
+
+ORTOLOCO_RECURRING_MESSAGES = [
+    {
+        "message": "OHNE TOFU"
+        ,"year": 2024
+        ,"weeks": list(range(1, 50, 2))
+    }
+]

--- a/ortoloco/settings.py
+++ b/ortoloco/settings.py
@@ -338,3 +338,41 @@ MAILER_RICHTEXT_OPTIONS = {
     'toolbar': "undo redo | bold italic | alignleft aligncenter alignright alignjustify | outdent indent | "
                "bullist numlist | link | fontselect fontsizeselect",
 }
+
+# hack to allow multiple products(sizes) on a subscription type
+ORTOLOCO_PRODUCTS = [{'name': 'Gemüse', 'sizes': [{'name': 'Tasche', 'key': 'gmues'}]},
+                {'name': 'Obst', 'sizes': [{'name': 'Portion', 'key': 'obst'}]},
+                {'name': 'Brot', 'sizes': [{'name': '500g', 'key': 'brot'}]},
+                {'name': 'Eier', 'sizes': [{'name': 'Schachtel', 'key': 'eier'}]},
+                {'name': 'Tofu', 'sizes': [{'name': 'Portion', 'key': 'tofu'}]}]
+
+ORTOLOCO_TYPE_SUBSCRIPTIONS = {
+    "gmues": [6, 7, 8, 9, 10, 11, 12, 13, 18],
+    "obst": [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 22, 31],
+    "brot": [8, 9, 12, 13, 16, 17, 19, 20],
+    "tofu": [30],
+    "eier": [23]
+}
+
+# #test version
+# ORTOLOCO_TYPE_SUBSCRIPTIONS = {
+#     "gmues": [1],
+#     "obst": [2],
+#     "brot": [3],
+#     "tofu": [4],
+#     "eier": [5]
+# }
+
+# hack to allow tours
+ORTOLOCO_TOURS = [
+    {"name": "Fondli", "depot_ids": [6, 17], "local": True},
+    {"name": "kleines Auto (Renault)", "depot_ids": [20, 13, 14, 3, 7, 10, 9, 15], "local": False},
+    {"name": "grosses Auto (Opel)", "depot_ids": [8, 12, 11, 2, 16, 5, 18, 19], "local": False}
+]
+
+# # test version
+# ORTOLOCO_TOURS = [
+#     {"name": "Fondli", "depot_ids": [1, 11], "local": True},
+#     {"name": "kleines Auto (Renault)", "depot_ids": [2, 3, 4, 5, 12, 13, 14], "local": False},
+#     {"name": "grosses Auto (Opel)", "depot_ids": [6, 7, 8, 9, 10, 15, 16, 17], "local": False}
+# ]

--- a/ortoloco/templates/exports_oooo/amount_overview.html
+++ b/ortoloco/templates/exports_oooo/amount_overview.html
@@ -11,9 +11,11 @@
 </head>
 
 <body>
-<div id="header_content">
+<div id="header_content" class="gendate">
     Erstellt am: {% now "d.m.Y H:i" %}
 </div>
+
+<h2 style="font-size: 18px;">{% trans "Mengen-Übersicht" %}</h2>
 
 <div>
     <table cellpadding="5" cellspacing="0" style="width:100%; margin-bottom:5px;" class="bottom-border">
@@ -26,7 +28,7 @@
         </tr>
         <tr>
             <td class="small bottom-border right-border"></td>
-            <td class="small bottom-border  right-border">{% trans "Abos" %}</td>
+            <td class="small bottom-border right-border">{% trans "Abos" %}</td>
             {% for product in products %}
                 {% for size in product.sizes %}
                     <td class="small bottom-border {% if forloop.first %}left-border{% endif %} {% cycle '' 'bg-grey' %}">{{ size.name }}</td>
@@ -57,6 +59,12 @@
             {% resetcycle %}
         </tr>
     </table>
+    <br>
+    {% for day in weekdays %}
+    {% include "./snippets/snippet_day_tour.html" with tour_name="" %}
+    <br>
+    {% endfor %}
+    
 </div>
 </body>
 </html>

--- a/ortoloco/templates/exports_oooo/amount_overview.html
+++ b/ortoloco/templates/exports_oooo/amount_overview.html
@@ -14,6 +14,11 @@
 <div id="header_content" class="gendate">
     Erstellt am: {% now "d.m.Y H:i" %}
 </div>
+<div id="footer_content">
+    {% for message in messages %}
+        <div class="message">{{ message }}</div>
+    {% endfor %}
+</div>
 
 <h2 style="font-size: 18px;">{% trans "Mengen-Übersicht" %}</h2>
 

--- a/ortoloco/templates/exports_oooo/depot_overview.html
+++ b/ortoloco/templates/exports_oooo/depot_overview.html
@@ -19,28 +19,42 @@
     <div class="messageb">Diese Liste bitte immer zurück ans Klemmbrett heften! Danke.</div>
 </div>
     <h2 style="font-size: 18px;">{{ day.name }}</h2>
-<table cellpadding="5" cellspacing="0" style="width:100%; margin-bottom:5px; border-collapse: collapse;" class="bottom-border">
+<table cellpadding="5" cellspacing="0" style="width:100%; margin-bottom:5px;" class="bottom-border">
     <tr>
-        <th style="small bottom-border right-border">{% trans "Tour" %}</th>
-        <th style="small bottom-border right-border">{% trans "Reihe" %}</th>
-        <th class="small bottom-border right-border">{% trans "Depot" %}</th>
-    </tr>
-    {% for tour in tours %}
-        {% for depot in depots|by_weekday:day.weekday|depots_by_tour:tour %}
-            <tr>
-                {% if not tour.local %}
-                    <td>{{tour.name}}</td>
-                {% else %}
-                    <td></td>
-                {% endif %}
-                <td>#{{ depot|depot_index:day_tours }}</td>
-                <td>{{ depot.name }}</td>
-            </tr>
+        <td></td>
+        {% for product in products %}
+            <th colspan="{{ product.sizes|count }}" class="top-border {% if forloop.first %}left-border{% endif %} right-border">{{ product.name }}<br/></th>
         {% endfor %}
+    </tr>
+    <tr>
+        <td></td>
+        {% for product in products %}
+            {% for size in product.sizes %}
+                <td class="small bottom-border {% if forloop.first %}left-border{% endif %} {% cycle '' 'bg-grey' %}">{{ size.name }}</td>
+            {% endfor %}
+        {% endfor %}
+        {% resetcycle %}
+    </tr>
+    {% for depot in depots|by_weekday:day.weekday %}
         <tr>
-            <td colspan="3"></td>
+            <td style="width:360px;">{{ depot.name }}</td>
+            {% for product in products %}
+                {% for size in product.sizes %}
+                    <td class="{% cycle '' 'bg-grey' %}">{{ depot|get_attr:size.key|default:'0' }}</td>
+                {% endfor %}
+            {% endfor %}
         </tr>
+        {% resetcycle %}
     {% endfor %}
+    <tr>
+        <td><b>{% trans "Total" %}</b></td>
+        {% for product in products %}
+            {% for size in product.sizes %}
+                <td class="{% cycle '' 'bg-grey' %}"><b>{{ day|get_attr:size.key|default:'0' }}</b></td>
+            {% endfor %}
+        {% endfor %}
+        {% resetcycle %}
+    </tr>
 </table>
 <div class="page-break"></div>
 {% endfor %}

--- a/ortoloco/templates/exports_oooo/depot_overview.html
+++ b/ortoloco/templates/exports_oooo/depot_overview.html
@@ -21,36 +21,36 @@
     <h2 style="font-size: 18px;">{{ day.name }}</h2>
 <table cellpadding="5" cellspacing="0" style="width:100%; margin-bottom:5px;" class="bottom-border">
     <tr>
-        <td style="width:230px"></td>
+        <td style="width:360px"></td>
         <td style="width:170px"></td>
-        {% for product in products %}
+        {% comment %} {% for product in products %}
             <th colspan="{{ product.sizes|count }}" class="top-border {% if forloop.first %}left-border{% endif %} right-border">{{ product.name }}<br/></th>
-        {% endfor %}
+        {% endfor %} {% endcomment %}
     </tr>
     <tr>
-        <td style="small bottom-border right-border"></td>
+        <td style="small bottom-border right-border">{% trans "Depot" %}</td>
         <td class="small bottom-border right-border">{% trans "Tour" %}</td>
-        {% for product in products %}
+        {% comment %} {% for product in products %}
             {% for size in product.sizes %}
                 <td class="small bottom-border {% if forloop.first %}left-border{% endif %} {% cycle '' 'bg-grey' %}">{{ size.name }}</td>
             {% endfor %}
         {% endfor %}
-        {% resetcycle %}
+        {% resetcycle %} {% endcomment %}
     </tr>
     {% for depot in depots|by_weekday:day.weekday %}
         <tr>
             <td>{{ depot.name }}</td>
             <td>{% for tour in tours|tours_by_depot:depot %}{% if not tour.local %}{{tour.name}}{% endif %}{% endfor %}</td>
             
-            {% for product in products %}
+            {% comment %} {% for product in products %}
                 {% for size in product.sizes %}
                     <td class="{% cycle '' 'bg-grey' %}">{{ depot|get_attr:size.key|default:'0' }}</td>
                 {% endfor %}
-            {% endfor %}
+            {% endfor %} {% endcomment %}
         </tr>
-        {% resetcycle %}
+        {% comment %} {% resetcycle %} {% endcomment %}
     {% endfor %}
-    <tr>
+    {% comment %} <tr>
         <td><b>{% trans "Total" %}</b></td>
         <td></td>
         {% for product in products %}
@@ -59,7 +59,7 @@
             {% endfor %}
         {% endfor %}
         {% resetcycle %}
-    </tr>
+    </tr> {% endcomment %}
 </table>
 <div class="page-break"></div>
 {% endfor %}

--- a/ortoloco/templates/exports_oooo/depot_overview.html
+++ b/ortoloco/templates/exports_oooo/depot_overview.html
@@ -19,47 +19,28 @@
     <div class="messageb">Diese Liste bitte immer zurück ans Klemmbrett heften! Danke.</div>
 </div>
     <h2 style="font-size: 18px;">{{ day.name }}</h2>
-<table cellpadding="5" cellspacing="0" style="width:100%; margin-bottom:5px;" class="bottom-border">
+<table cellpadding="5" cellspacing="0" style="width:100%; margin-bottom:5px; border-collapse: collapse;" class="bottom-border">
     <tr>
-        <td style="width:360px"></td>
-        <td style="width:170px"></td>
-        {% comment %} {% for product in products %}
-            <th colspan="{{ product.sizes|count }}" class="top-border {% if forloop.first %}left-border{% endif %} right-border">{{ product.name }}<br/></th>
-        {% endfor %} {% endcomment %}
+        <th style="small bottom-border right-border">{% trans "Tour" %}</th>
+        <th style="small bottom-border right-border">{% trans "Reihe" %}</th>
+        <th class="small bottom-border right-border">{% trans "Depot" %}</th>
     </tr>
-    <tr>
-        <td style="small bottom-border right-border">{% trans "Depot" %}</td>
-        <td class="small bottom-border right-border">{% trans "Tour" %}</td>
-        {% comment %} {% for product in products %}
-            {% for size in product.sizes %}
-                <td class="small bottom-border {% if forloop.first %}left-border{% endif %} {% cycle '' 'bg-grey' %}">{{ size.name }}</td>
-            {% endfor %}
+    {% for tour in tours %}
+        {% for depot in depots|by_weekday:day.weekday|depots_by_tour:tour %}
+            <tr>
+                {% if not tour.local %}
+                    <td>{{tour.name}}</td>
+                {% else %}
+                    <td></td>
+                {% endif %}
+                <td>#{{ depot|depot_index:day_tours }}</td>
+                <td>{{ depot.name }}</td>
+            </tr>
         {% endfor %}
-        {% resetcycle %} {% endcomment %}
-    </tr>
-    {% for depot in depots|by_weekday:day.weekday %}
         <tr>
-            <td>{{ depot.name }}</td>
-            <td>{% for tour in tours|tours_by_depot:depot %}{% if not tour.local %}{{tour.name}}{% endif %}{% endfor %}</td>
-            
-            {% comment %} {% for product in products %}
-                {% for size in product.sizes %}
-                    <td class="{% cycle '' 'bg-grey' %}">{{ depot|get_attr:size.key|default:'0' }}</td>
-                {% endfor %}
-            {% endfor %} {% endcomment %}
+            <td colspan="3"></td>
         </tr>
-        {% comment %} {% resetcycle %} {% endcomment %}
     {% endfor %}
-    {% comment %} <tr>
-        <td><b>{% trans "Total" %}</b></td>
-        <td></td>
-        {% for product in products %}
-            {% for size in product.sizes %}
-                <td class="{% cycle '' 'bg-grey' %}"><b>{{ day|get_attr:size.key|default:'0' }}</b></td>
-            {% endfor %}
-        {% endfor %}
-        {% resetcycle %}
-    </tr> {% endcomment %}
 </table>
 <div class="page-break"></div>
 {% endfor %}

--- a/ortoloco/templates/exports_oooo/snippets/snippet_day_tour.html
+++ b/ortoloco/templates/exports_oooo/snippets/snippet_day_tour.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load ortoloco_common %}
 {% load juntagrico.config %}
-<h2 style="font-size: 18px;">{{ tour_name }} {% trans "Übersicht" %}: {{ day.name }}</h2>
+<h2 style="font-size: 18px;">{{ tour_name }} {% trans "Übersicht" %}: {{ day.name }} - {{ day.weekday|get_date:weekdays }}</h2>
 <table cellpadding="5" cellspacing="0" style="width:100%; margin-bottom:5px;" class="bottom-border">
     <tr>
         <td></td>

--- a/ortoloco/templates/exports_oooo/snippets/snippet_day_tour.html
+++ b/ortoloco/templates/exports_oooo/snippets/snippet_day_tour.html
@@ -1,35 +1,17 @@
-{% load ortoloco_common %}
 {% load juntagrico.depot_extras %}
-
 {% load i18n %}
+{% load ortoloco_common %}
 {% load juntagrico.config %}
-{% vocabulary "depot" as v_depot %}
-<html>
-<head>
-    <title>{% blocktrans %}{{ v_depot }} Übersicht{% endblocktrans %}</title>
-    <meta charset="utf-8">
-    <style>{% include "./snippets/snippet_depotlist_style.css" %}</style>
-</head>
-<body>
-{% for day in weekdays %}
-<div id="header_content" class="gendate">
-    Erstellt am: {% now "d.m.Y H:i" %}
-</div>
-<div id="footer_content">
-    <div class="messageb">Diese Liste bitte immer zurück ans Klemmbrett heften! Danke.</div>
-</div>
-    <h2 style="font-size: 18px;">{{ day.name }}</h2>
+<h2 style="font-size: 18px;">{{ tour_name }} {% trans "Übersicht" %}: {{ day.name }}</h2>
 <table cellpadding="5" cellspacing="0" style="width:100%; margin-bottom:5px;" class="bottom-border">
     <tr>
-        <td style="width:230px"></td>
-        <td style="width:170px"></td>
+        <td></td>
         {% for product in products %}
             <th colspan="{{ product.sizes|count }}" class="top-border {% if forloop.first %}left-border{% endif %} right-border">{{ product.name }}<br/></th>
         {% endfor %}
     </tr>
     <tr>
-        <td style="small bottom-border right-border"></td>
-        <td class="small bottom-border right-border">{% trans "Tour" %}</td>
+        <td></td>
         {% for product in products %}
             {% for size in product.sizes %}
                 <td class="small bottom-border {% if forloop.first %}left-border{% endif %} {% cycle '' 'bg-grey' %}">{{ size.name }}</td>
@@ -37,22 +19,25 @@
         {% endfor %}
         {% resetcycle %}
     </tr>
-    {% for depot in depots|by_weekday:day.weekday %}
+    {% for day_tour in day_tours %}
+    {% if day_tour.day.weekday == day.weekday %}
         <tr>
-            <td>{{ depot.name }}</td>
-            <td>{% for tour in tours|tours_by_depot:depot %}{% if not tour.local %}{{tour.name}}{% endif %}{% endfor %}</td>
-            
+            <td style="width:360px;" {% if day_tour.tour == tour_name %}class="bg-grey"{% endif %}>{{ day_tour.tour }}</td>
             {% for product in products %}
                 {% for size in product.sizes %}
-                    <td class="{% cycle '' 'bg-grey' %}">{{ depot|get_attr:size.key|default:'0' }}</td>
+                    <td class="{% cycle '' 'bg-grey' %}">
+                        {% if day_tour.tour == tour_name %}<b>{% endif %}
+                            {{ day_tour|get_attr:size.key|default:'0' }}
+                        {% if day_tour.tour == tour_name %}</b>{% endif %}
+                    </td>
                 {% endfor %}
             {% endfor %}
-        </tr>
+            </tr>
         {% resetcycle %}
+    {% endif %}
     {% endfor %}
     <tr>
         <td><b>{% trans "Total" %}</b></td>
-        <td></td>
         {% for product in products %}
             {% for size in product.sizes %}
                 <td class="{% cycle '' 'bg-grey' %}"><b>{{ day|get_attr:size.key|default:'0' }}</b></td>
@@ -61,7 +46,3 @@
         {% resetcycle %}
     </tr>
 </table>
-<div class="page-break"></div>
-{% endfor %}
-</body>
-</html>

--- a/ortoloco/templates/exports_oooo/snippets/snippet_depotlist_header.html
+++ b/ortoloco/templates/exports_oooo/snippets/snippet_depotlist_header.html
@@ -4,20 +4,22 @@
 {% load juntagrico.config %}
 <table cellpadding="2" cellspacing="0" repeat="5">
     <tr>
-        <th colspan="3" class="horz-left">{% comment "#TODO: get number of columns from data. workaround: there will be at least 3 columns" %}{% endcomment %}
-            <h2 class="depot">Depotliste: {{ depot.weekday_name }} / {{ depot.name }}</h2>
-            <h3 class="depotaddr">{{ depot.addr_street }}, {{ depot.addr_zipcode }} {{ depot.addr_location }} ({% trans "Kontakt" %}: {{ depot.contact.first_name }} {{ depot.contact.last_name }})
-                {% for depot_tour in tours|tours_by_depot:depot %}
-                {% if not depot_tour.local %}
-                    , {% trans "Tour" %}: {{ depot_tour.name }}
-                {% endif %}
-                {% endfor %}
+        <th colspan="5" class="horz-left">{% comment "#TODO: get number of columns from data. workaround: there will be at least 3 columns" %}{% endcomment %}
+            <h2 class="depot">Depotliste: {{ depot.weekday_name }} {{ depot.weekday|get_date:weekdays }}<br>
+            {{ depot.name }}</h2>
+            <h3 class="depotaddr">{{ depot.location.addr_street }}, {{ depot.location.addr_zipcode }} {{ depot.location.addr_location }} ({% trans "Kontakt" %}: {{ depot.contact.first_name }} {{ depot.contact.last_name }})
             </h3>
             <br />
         </th>
     </tr>
     <tr>
-        <th class="namecol"></th>
+        <th class="namecol horz-left">
+            {% for depot_tour in tours|tours_by_depot:depot %}
+            {% if not depot_tour.local %}
+                {% trans "Tour" %}: {{ depot_tour.name }} #{{ depot|depot_index:day_tours }}
+            {% endif %}
+            {% endfor %}
+        </th>
         {% for product in products %}
             <th colspan="{{ product.sizes|count }}" class="top-border {% if forloop.first %}left-border{% endif %} right-border">{{ product.name }}</th>
         {% endfor %}

--- a/ortoloco/templates/exports_oooo/snippets/snippet_depotlist_header.html
+++ b/ortoloco/templates/exports_oooo/snippets/snippet_depotlist_header.html
@@ -7,9 +7,9 @@
         <th colspan="3" class="horz-left">{% comment "#TODO: get number of columns from data. workaround: there will be at least 3 columns" %}{% endcomment %}
             <h2 class="depot">Depotliste: {{ depot.weekday_name }} / {{ depot.name }}</h2>
             <h3 class="depotaddr">{{ depot.addr_street }}, {{ depot.addr_zipcode }} {{ depot.addr_location }} ({% trans "Kontakt" %}: {{ depot.contact.first_name }} {{ depot.contact.last_name }})
-                {% for tour in tours %}
-                {% if not tour.local and depot.id in tour.depot_ids %}
-                    , {% trans "Tour" %}: {{ tour.name }}
+                {% for depot_tour in tours|tours_by_depot:depot %}
+                {% if not depot_tour.local %}
+                    , {% trans "Tour" %}: {{ depot_tour.name }}
                 {% endif %}
                 {% endfor %}
             </h3>

--- a/ortoloco/templates/exports_oooo/snippets/snippet_depotlist_header.html
+++ b/ortoloco/templates/exports_oooo/snippets/snippet_depotlist_header.html
@@ -6,7 +6,13 @@
     <tr>
         <th colspan="3" class="horz-left">{% comment "#TODO: get number of columns from data. workaround: there will be at least 3 columns" %}{% endcomment %}
             <h2 class="depot">Depotliste: {{ depot.weekday_name }} / {{ depot.name }}</h2>
-            <h3 class="depotaddr">{{ depot.addr_street }}, {{ depot.addr_zipcode }} {{ depot.addr_location }} ({% trans "Kontakt" %}: {{ depot.contact.first_name }} {{ depot.contact.last_name }})</h3>
+            <h3 class="depotaddr">{{ depot.addr_street }}, {{ depot.addr_zipcode }} {{ depot.addr_location }} ({% trans "Kontakt" %}: {{ depot.contact.first_name }} {{ depot.contact.last_name }})
+                {% for tour in tours %}
+                {% if not tour.local and depot.id in tour.depot_ids %}
+                    , {% trans "Tour" %}: {{ tour.name }}
+                {% endif %}
+                {% endfor %}
+            </h3>
             <br />
         </th>
     </tr>

--- a/ortoloco/templates/exports_oooo/tour_list.html
+++ b/ortoloco/templates/exports_oooo/tour_list.html
@@ -12,59 +12,17 @@
 </head>
 <body>
 
+    <div id="header_content" class="gendate">
+        Erstellt am: {% now "d.m.Y H:i" %}
+    </div>
+    <div id="footer_content">
+        <div class="messageb">Diese Liste Nimmt ihr mit!</div>
+    </div>
+
 {% for day in weekdays %}
-<div id="header_content" class="gendate">
-    Erstellt am: {% now "d.m.Y H:i" %}
-</div>
-<div id="footer_content">
-    <div class="messageb">Diese Liste Nimmt ihr mit!</div>
-</div>
 {% for tour in tours  %}
 {% if not tour.local %}
-    <h2 style="font-size: 18px;">{{ tour.name }} Übersicht: {{ day.name }}</h2>
-<table cellpadding="5" cellspacing="0" style="width:100%; margin-bottom:5px;" class="bottom-border">
-    <tr>
-        <td></td>
-        {% for product in products %}
-            <th colspan="{{ product.sizes|count }}" class="top-border {% if forloop.first %}left-border{% endif %} right-border">{{ product.name }}<br/></th>
-        {% endfor %}
-    </tr>
-    <tr>
-        <td></td>
-        {% for product in products %}
-            {% for size in product.sizes %}
-                <td class="small bottom-border {% if forloop.first %}left-border{% endif %} {% cycle '' 'bg-grey' %}">{{ size.name }}</td>
-            {% endfor %}
-        {% endfor %}
-        {% resetcycle %}
-    </tr>
-    {% for day_tour in day_tours %}
-    {% if day_tour.day.weekday == day.weekday %}
-        <tr>
-            <td style="width:360px;" {% if day_tour.tour == tour.name %}class="bg-grey"{% endif %}>{{ day_tour.tour }}</td>
-            {% for product in products %}
-                {% for size in product.sizes %}
-                    <td class="{% cycle '' 'bg-grey' %}">
-                        {% if day_tour.tour == tour.name %}<b>{% endif %}
-                            {{ day_tour|get_attr:size.key|default:'0' }}
-                        {% if day_tour.tour == tour.name %}</b>{% endif %}
-                    </td>
-                {% endfor %}
-            {% endfor %}
-            </tr>
-        {% resetcycle %}
-    {% endif %}
-    {% endfor %}
-    <tr>
-        <td><b>{% trans "Total" %}</b></td>
-        {% for product in products %}
-            {% for size in product.sizes %}
-                <td class="{% cycle '' 'bg-grey' %}"><b>{{ day|get_attr:size.key|default:'0' }}</b></td>
-            {% endfor %}
-        {% endfor %}
-        {% resetcycle %}
-    </tr>
-</table>
+{% include "./snippets/snippet_day_tour.html" with tour_name=tour.name %}
 <div class="page-break"></div>
 {% endif %}
 {% endfor %}

--- a/ortoloco/templates/exports_oooo/tour_list.html
+++ b/ortoloco/templates/exports_oooo/tour_list.html
@@ -11,15 +11,17 @@
     <style>{% include "./snippets/snippet_depotlist_style.css" %}</style>
 </head>
 <body>
-{% for day_tour in day_tours %}
-{% if not day_tour.local %}
+
+{% for day in weekdays %}
 <div id="header_content" class="gendate">
     Erstellt am: {% now "d.m.Y H:i" %}
 </div>
 <div id="footer_content">
-    <div class="messageb">Diese Liste bleibt auf dem Hof! Bitte zurück an die Klemmbretter heften. Danke.</div>
+    <div class="messageb">Diese Liste Nimmt ihr mit!</div>
 </div>
-    <h2 style="font-size: 18px;">Auto-Pack-Liste: {{ day_tour.name }}</h2>
+{% for tour in tours  %}
+{% if not tour.local %}
+    <h2 style="font-size: 18px;">{{ tour.name }} Übersicht: {{ day.name }}</h2>
 <table cellpadding="5" cellspacing="0" style="width:100%; margin-bottom:5px;" class="bottom-border">
     <tr>
         <td></td>
@@ -36,22 +38,28 @@
         {% endfor %}
         {% resetcycle %}
     </tr>
-    {% for depot in day_tour.depots %}
+    {% for day_tour in day_tours %}
+    {% if day_tour.day.weekday == day.weekday %}
         <tr>
-            <td style="width:360px;">{{ depot.name }}</td>
+            <td style="width:360px;" {% if day_tour.tour == tour.name %}class="bg-grey"{% endif %}>{{ day_tour.tour }}</td>
             {% for product in products %}
                 {% for size in product.sizes %}
-                    <td class="{% cycle '' 'bg-grey' %}">{{ depot|get_attr:size.key|default:'0' }}</td>
+                    <td class="{% cycle '' 'bg-grey' %}">
+                        {% if day_tour.tour == tour.name %}<b>{% endif %}
+                            {{ day_tour|get_attr:size.key|default:'0' }}
+                        {% if day_tour.tour == tour.name %}</b>{% endif %}
+                    </td>
                 {% endfor %}
             {% endfor %}
-        </tr>
+            </tr>
         {% resetcycle %}
+    {% endif %}
     {% endfor %}
     <tr>
         <td><b>{% trans "Total" %}</b></td>
         {% for product in products %}
             {% for size in product.sizes %}
-                <td class="{% cycle '' 'bg-grey' %}"><b>{{ day_tour|get_attr:size.key|default:'0' }}</b></td>
+                <td class="{% cycle '' 'bg-grey' %}"><b>{{ day|get_attr:size.key|default:'0' }}</b></td>
             {% endfor %}
         {% endfor %}
         {% resetcycle %}
@@ -60,5 +68,7 @@
 <div class="page-break"></div>
 {% endif %}
 {% endfor %}
+{% endfor %}
+
 </body>
 </html>

--- a/ortoloco/templates/exports_oooo/tour_overview.html
+++ b/ortoloco/templates/exports_oooo/tour_overview.html
@@ -11,54 +11,38 @@
     <style>{% include "./snippets/snippet_depotlist_style.css" %}</style>
 </head>
 <body>
-{% for day_tour in day_tours %}
-{% if not day_tour.local %}
+{% for day in weekdays %}
 <div id="header_content" class="gendate">
     Erstellt am: {% now "d.m.Y H:i" %}
 </div>
 <div id="footer_content">
-    <div class="messageb">Diese Liste bleibt auf dem Hof! Bitte zurück an die Klemmbretter heften. Danke.</div>
+    <div class="messageb">Diese Liste bitte immer zurück ans Klemmbrett heften! Danke.</div>
 </div>
-    <h2 style="font-size: 18px;">Auto-Pack-Liste: {{ day_tour.name }}</h2>
-<table cellpadding="5" cellspacing="0" style="width:100%; margin-bottom:5px;" class="bottom-border">
+    <h2 style="font-size: 18px;">{{ day.name }}</h2>
+<table cellpadding="5" cellspacing="0" style="width:100%; margin-bottom:5px; border-collapse: collapse;" class="bottom-border">
     <tr>
-        <td></td>
-        {% for product in products %}
-            <th colspan="{{ product.sizes|count }}" class="top-border {% if forloop.first %}left-border{% endif %} right-border">{{ product.name }}<br/></th>
-        {% endfor %}
+        <th style="small bottom-border right-border">{% trans "Tour" %}</th>
+        <th style="small bottom-border right-border">{% trans "Reihe" %}</th>
+        <th class="small bottom-border right-border">{% trans "Depot" %}</th>
     </tr>
-    <tr>
-        <td></td>
-        {% for product in products %}
-            {% for size in product.sizes %}
-                <td class="small bottom-border {% if forloop.first %}left-border{% endif %} {% cycle '' 'bg-grey' %}">{{ size.name }}</td>
-            {% endfor %}
+    {% for tour in tours %}
+        {% for depot in depots|by_weekday:day.weekday|depots_by_tour:tour %}
+            <tr>
+                {% if not tour.local %}
+                    <td>{{tour.name}}</td>
+                {% else %}
+                    <td></td>
+                {% endif %}
+                <td>#{{ depot|depot_index:day_tours }}</td>
+                <td>{{ depot.name }}</td>
+            </tr>
         {% endfor %}
-        {% resetcycle %}
-    </tr>
-    {% for depot in day_tour.depots %}
         <tr>
-            <td style="width:360px;">{{ depot.name }}</td>
-            {% for product in products %}
-                {% for size in product.sizes %}
-                    <td class="{% cycle '' 'bg-grey' %}">{{ depot|get_attr:size.key|default:'0' }}</td>
-                {% endfor %}
-            {% endfor %}
+            <td colspan="3"></td>
         </tr>
-        {% resetcycle %}
     {% endfor %}
-    <tr>
-        <td><b>{% trans "Total" %}</b></td>
-        {% for product in products %}
-            {% for size in product.sizes %}
-                <td class="{% cycle '' 'bg-grey' %}"><b>{{ day_tour|get_attr:size.key|default:'0' }}</b></td>
-            {% endfor %}
-        {% endfor %}
-        {% resetcycle %}
-    </tr>
 </table>
 <div class="page-break"></div>
-{% endif %}
 {% endfor %}
 </body>
 </html>

--- a/ortoloco/templates/mails/admin/depot_list_generated.txt
+++ b/ortoloco/templates/mails/admin/depot_list_generated.txt
@@ -11,6 +11,7 @@
 {{ v_depot }}-{% trans "Übersicht" %}: {{ serverurl }}{% url 'lists-depot-overview' %}
 {% trans "Mengen-Übersicht" %}: {{ serverurl }}{% url 'lists-depot-amountoverview' %}
 {% trans "Tour-Übersicht" %}: {{ serverurl }}{% url 'lists-depot-touroverview' %}
+{% trans "Tour-Totals" %}: {{ serverurl }}{% url 'lists-depot-tourlist' %}
 
 {% blocktrans %}Liebe Grüsse und einen schönen Tag noch
 Dein Server{% endblocktrans %}

--- a/ortoloco/templates/menu/admin_menu.html
+++ b/ortoloco/templates/menu/admin_menu.html
@@ -267,6 +267,11 @@
                             Tour {% trans "Übersicht" %}
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{% url 'lists-depot-tourlist' %}">
+                            Tour {% trans "Details" %}
+                        </a>
+                    </li>
                 </ul>
             </div>
         </li>

--- a/ortoloco/templatetags/ortoloco_common.py
+++ b/ortoloco/templatetags/ortoloco_common.py
@@ -13,8 +13,21 @@ def get_attr(value, arg):
 
 @register.filter
 def tours_by_depot(tours, depot):
-    return [
-        tour
-        for tour in tours
-        if depot.id in tour['depot_ids']
-    ]
+    return [tour for tour in tours if depot.id in tour["depot_ids"]]
+
+@register.filter
+def depots_by_tour(depots, tour):
+    return [depot for depot in depots if depot.id in tour["depot_ids"]]
+
+@register.filter
+def depot_index(depot, day_tours):
+    for day_tour in day_tours:
+        if day_tour["day"]["weekday"] == depot.weekday:
+            for depot_index, day_tour_depot in enumerate(day_tour['depots']):
+                if depot == day_tour_depot:
+                    return depot_index + 1
+    return 0
+
+@register.filter
+def get_date(weekday, days):
+    return [day["date"] for day in days if day['weekday'] == weekday][0]

--- a/ortoloco/templatetags/ortoloco_common.py
+++ b/ortoloco/templatetags/ortoloco_common.py
@@ -7,7 +7,14 @@ register = template.Library()
 def get_attr(value, arg):
     if hasattr(value, str(arg)):
         return getattr(value, arg)
-    elif hasattr(value, 'get'):
+    if hasattr(value, 'get'):
         return value.get(arg)
-    else:
-        ''
+    return ''
+
+@register.filter
+def tours_by_depot(tours, depot):
+    return [
+        tour
+        for tour in tours
+        if depot.id in tour['depot_ids']
+    ]

--- a/ortoloco/templatetags/ortoloco_common.py
+++ b/ortoloco/templatetags/ortoloco_common.py
@@ -11,14 +11,3 @@ def get_attr(value, arg):
         return value.get(arg)
     else:
         ''
-@register.filter
-def by_tour(queryset_depots, tour_id):
-    # quick and dirty assignment depot_ids to tours, defined here and in depot_list.py
-    tour_depots = [[6],
-                   [20, 13, 14, 3],
-                   [8, 12, 11, 2, 16],
-                   [17],
-                   [7, 15, 9, 10],
-                   [5, 18, 19]]
-    depot_ids = tour_depots[tour_id]
-    return queryset_depots.filter(id__in=depot_ids)

--- a/ortoloco/urls.py
+++ b/ortoloco/urls.py
@@ -44,4 +44,5 @@ urlpatterns = [
     re_path('__debug__/', include(debug_toolbar.urls)),
 
     path('my/pdf/touroverview', ortoloco.tour_overview, name='lists-depot-touroverview'),
+    path('my/pdf/tourlist', ortoloco.tour_list, name='lists-depot-tourlist'),
 ]

--- a/ortoloco/util/depot_list.py
+++ b/ortoloco/util/depot_list.py
@@ -1,17 +1,16 @@
 from django.conf import settings
-from django.utils import timezone, dateformat
-from django.db.models import Count, Q
 from django.core.files.storage import default_storage
-
+from django.db.models import Count, Q
+from django.utils import dateformat, timezone
 from juntagrico.config import Config
 from juntagrico.dao.depotdao import DepotDao
 from juntagrico.dao.listmessagedao import ListMessageDao
 from juntagrico.dao.subscriptiondao import SubscriptionDao
-from juntagrico.util.pdf import render_to_pdf_storage
-from juntagrico.util.temporal import weekdays
-from juntagrico.util.subs import activate_future_depots
-from juntagrico.entity.subtypes import SubscriptionType, SubscriptionProduct, SubscriptionSize
+from juntagrico.entity.subtypes import SubscriptionType
 from juntagrico.mailer import adminnotification
+from juntagrico.util.pdf import render_to_pdf_storage
+from juntagrico.util.subs import activate_future_depots
+from juntagrico.util.temporal import weekdays
 
 
 def depot_list_generation(*args, **options):
@@ -37,6 +36,7 @@ def depot_list_generation(*args, **options):
     }
 
     now = dateformat.format(timezone.now(), 'Y-m-d')
+    list_week_date = timezone.localdate() + timezone.timedelta(days=7-timezone.localdate().weekday())
 
     # annotate all subscriptions with the count of product keys
     subs = SubscriptionDao.all_active_subscritions(). \
@@ -72,6 +72,7 @@ def depot_list_generation(*args, **options):
 
     for day in days:
         day['name'] = weekdays[day['weekday']]
+        day['date'] = list_week_date + timezone.timedelta(days=day['weekday'])
 
     # daily tours (as opposed to the logical tours - ortoloco_tours)
     day_tours = [

--- a/ortoloco/views.py
+++ b/ortoloco/views.py
@@ -49,3 +49,7 @@ def beipackzettel_profile(request):
 @permission_required('juntagrico.can_view_lists')
 def tour_overview(request):
     return return_pdf_http('tour_overview.pdf')
+
+@permission_required('juntagrico.can_view_lists')
+def tour_list(request):
+    return return_pdf_http('tour_list.pdf')


### PR DESCRIPTION
moved the hardcoded stuff to the settings
removed local tours from the tour_overview as the new tour list is enough added the tour name on the depot list for easier delivery

Edit:
samples of the changes in the generated lists
[tour_list.pdf](https://github.com/ortoloco/ortoloco/files/13658291/tour_list.pdf)
[tour_overview.pdf](https://github.com/ortoloco/ortoloco/files/13658292/tour_overview.pdf)
[depotlist.pdf](https://github.com/ortoloco/ortoloco/files/13658293/depotlist.pdf)
