### PR TITLE
version specific reference to juntagrico-billing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ psycopg2==2.8.4
 django-mail-queue==3.2.2
 juntagrico-webdav~=1.5.0
 juntagrico-pg~=1.5.0
-git+https://github.com/juntagrico/juntagrico-billing
+juntagrico-billing~=1.5.0
 git+https://github.com/nixnuex/juntagrico-polling@remove_menudict
 django-oauth-toolkit==1.7.0
 git+https://github.com/juanifioren/django-oidc-provider@develop


### PR DESCRIPTION
reference juntagrico-billing as pypi package with version.
is a preparation for the upgrade to juntagrico 1.6.0 and prevents automatic update of billing when release 1.6.0 will be published.